### PR TITLE
feat: Implement task history and pending task tables

### DIFF
--- a/src/components/bulk-email-tool/bulk-email-task-manager/BulkEmailHistoryTable.jsx
+++ b/src/components/bulk-email-tool/bulk-email-task-manager/BulkEmailHistoryTable.jsx
@@ -1,0 +1,86 @@
+import { Alert, DataTable } from '@edx/paragon';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+export default function BulkEmailTaskManagerTable(props) {
+  const {
+    errorRetrievingData,
+    tableData,
+    tableDescription,
+    alertWarningMessage,
+    alertErrorMessage,
+    columns,
+    additionalColumns,
+  } = props;
+
+  /**
+   * Sub-render function that creates an Alert component with a specific type and message for display to a user.
+   */
+  const renderAlert = (alertType, alertMessage) => (
+    <div className="pt-1">
+      <Alert variant={`${alertType}`}>
+        <p className="font-weight-bold">
+          {`${alertMessage}`}
+        </p>
+      </Alert>
+    </div>
+  );
+
+  /**
+   * Responsible for rendering the tables used by the BulkEmailContentHistory, BulkEmailTaskManager, and
+   * BulkEmailTaskHistory components. Conditionally renders a table description as well.
+   */
+  const renderTable = () => (
+    <div className="pb-3">
+      {tableDescription && (
+        <p className="font-italic">
+          {tableDescription}
+        </p>
+      )}
+      <DataTable
+        itemCount={tableData.length}
+        columns={columns}
+        data={tableData}
+        additionalColumns={additionalColumns}
+      />
+    </div>
+  );
+
+  /**
+   * Sub-render function that determines if we can render the DataTable. If not, we will render an Alert component to
+   * inform the user why the data/table cannot be displayed.
+   */
+  const canRenderTable = () => {
+    if (errorRetrievingData) {
+      return renderAlert('danger', alertErrorMessage);
+    }
+
+    if (!tableData.length) {
+      return renderAlert('warning', alertWarningMessage);
+    }
+
+    return renderTable();
+  };
+
+  return (
+    <div>
+      {canRenderTable()}
+    </div>
+  );
+}
+
+BulkEmailTaskManagerTable.propTypes = {
+  errorRetrievingData: PropTypes.bool.isRequired,
+  tableData: PropTypes.arrayOf(PropTypes.object),
+  tableDescription: PropTypes.string,
+  alertWarningMessage: PropTypes.string.isRequired,
+  alertErrorMessage: PropTypes.string.isRequired,
+  columns: PropTypes.arrayOf(PropTypes.object).isRequired,
+  additionalColumns: PropTypes.arrayOf(PropTypes.object),
+};
+
+BulkEmailTaskManagerTable.defaultProps = {
+  tableData: [],
+  tableDescription: '',
+  additionalColumns: [],
+};

--- a/src/components/bulk-email-tool/bulk-email-task-manager/BulkEmailTaskManager.jsx
+++ b/src/components/bulk-email-tool/bulk-email-task-manager/BulkEmailTaskManager.jsx
@@ -1,30 +1,23 @@
 import React from 'react';
 
-import { FormattedMessage } from '@edx/frontend-platform/i18n';
+import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import BulkEmailContentHistory from './BulkEmailContentHistory';
 import BulkEmailPendingTasks from './BulkEmailPendingTasks';
 import BulkEmailTaskHistory from './BulkEmailTaskHistory';
+import messages from './messages';
 
-export default function BulkEmailTaskManager() {
+export function BulkEmailTaskManager({ intl }) {
   return (
     <div className="px-5">
       <div>
         <h2 className="h3">
-          <FormattedMessage
-            id="bulk.email.pending.tasks.section.heading"
-            defaultMessage="Pending Tasks"
-            description="A section to see pending and executing Instructor Tasks"
-          />
+          {intl.formatMessage(messages.pendingTasksHeader)}
         </h2>
         <BulkEmailPendingTasks />
       </div>
       <div>
         <h2 className="h3">
-          <FormattedMessage
-            id="bulk.email.task.manager.heading"
-            defaultMessage="Email Task History"
-            description="Title of the Email task History section of the Bulk Course Email tool"
-          />
+          {intl.formatMessage(messages.emailTaskHistoryHeader)}
         </h2>
         <BulkEmailContentHistory />
       </div>
@@ -34,3 +27,9 @@ export default function BulkEmailTaskManager() {
     </div>
   );
 }
+
+BulkEmailTaskManager.propTypes = {
+  intl: intlShape.isRequired,
+};
+
+export default injectIntl(BulkEmailTaskManager);

--- a/src/components/bulk-email-tool/bulk-email-task-manager/messages.js
+++ b/src/components/bulk-email-tool/bulk-email-task-manager/messages.js
@@ -2,13 +2,13 @@ import { defineMessages } from '@edx/frontend-platform/i18n';
 
 const messages = defineMessages({
   /* BulkEmailContentHistory.jsx Messages */
-  errorFetchingData: {
+  errorFetchingEmailHistoryData: {
     id: 'bulk.email.content.history.table.alert.errorFetchingData',
     defaultMessage: 'An error occurred retrieving email history data for this course. Please try again later.',
   },
   noEmailData: {
     id: 'bulk.email.content.history.table.alert.noEmailData',
-    defaultMessage: 'There is no email history for this course',
+    defaultMessage: 'There is no email history for this course.',
   },
   buttonViewMessage: {
     id: 'bulk.email.content.history.table.button.viewMessage',
@@ -71,8 +71,81 @@ const messages = defineMessages({
     defaultMessage: 'Show Sent Email History',
   },
   /* BulkEmailTaskManager.jsx messages */
+  pendingTasksHeader: {
+    id: 'bulk.email.pending.tasks.header',
+    defaultMessage: 'Pending Tasks',
+  },
+  emailTaskHistoryHeader: {
+    id: 'bulk.email.email.task.history.header',
+    defaultMessage: 'Email Task History',
+  },
   /* BulkEmailPendingTasks.jsx messages */
+  pendingTaskSectionInfo: {
+    id: 'bulk.email.pending.tasks.section.info',
+    defaultMessage: 'Email actions run in the background. The status for any active tasks - including email tasks - appears in the table below.',
+  },
+  errorFetchingPendingTaskData: {
+    id: 'bulk.email.pending.tasks.table.alert.errorFetchingData',
+    defaultMessage: 'Error fetching Instructor Task data. This request will be retried automatically.',
+  },
+  noPendingTaskData: {
+    id: 'bulk.email.pending.tasks.table.alert.noTaskData',
+    defaultMessage: 'No tasks currently running.',
+  },
   /* BulkEmailTaskHistory.jsx messages */
+  emailTaskHistoryTableSectionButtonHeader: {
+    id: 'bulk.email.task.history.table.button.header',
+    defaultMessage: 'To see the status for all email tasks submitted for this course, click this button:',
+  },
+  emailTaskHistoryTableSectionButton: {
+    id: 'bulk.email.task.history.table.button',
+    defaultMessage: 'Show Email Task History',
+  },
+  errorFetchingTaskHistoryData: {
+    id: 'bulk.email.task.history.table.alert.errorFetchingData',
+    defaultMessage: 'Error fetching email task history data for this course. Please try again later.',
+  },
+  noTaskHistoryData: {
+    id: 'bulk.email.task.history.table.alert.noTaskData',
+    defaultMessage: 'There is no email task history for this course.',
+  },
+  /* Common Messages */
+  taskHistoryTableColumnHeaderTaskType: {
+    id: 'bulk.email.task.history.table.column.header.taskType',
+    defaultMessage: 'Task Type',
+  },
+  taskHistoryTableColumnHeaderTaskInputs: {
+    id: 'bulk.email.task.history.table.column.header.taskInputs',
+    defaultMessage: 'Task Inputs',
+  },
+  taskHistoryTableColumnHeaderTaskId: {
+    id: 'bulk.email.task.history.table.column.header.taskId',
+    defaultMessage: 'Task Id',
+  },
+  taskHistoryTableColumnHeaderTaskRequester: {
+    id: 'bulk.email.task.history.table.column.header.taskRequester',
+    defaultMessage: 'Requester',
+  },
+  taskHistoryTableColumnHeaderTaskSubmittedDate: {
+    id: 'bulk.email.task.history.table.column.header.taskSubmittedDate',
+    defaultMessage: 'Submitted',
+  },
+  taskHistoryTableColumnHeaderTaskDuration: {
+    id: 'bulk.email.task.history.table.column.header.taskDuration',
+    defaultMessage: 'Duration (seconds)',
+  },
+  taskHistoryTableColumnHeaderTaskState: {
+    id: 'bulk.email.task.history.table.column.header.taskState',
+    defaultMessage: 'State',
+  },
+  taskHistoryTableColumnHeaderTaskStatus: {
+    id: 'bulk.email.task.history.table.column.header.taskStatus',
+    defaultMessage: 'Status',
+  },
+  taskHistoryTableColumnHeaderTaskProgress: {
+    id: 'bulk.email.task.history.table.column.header.taskProgress',
+    defaultMessage: 'Task Progress',
+  },
 });
 
 export default messages;

--- a/src/utils/useInterval.js
+++ b/src/utils/useInterval.js
@@ -1,0 +1,28 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * A custom hook used by the BulkEmailPendingTasks component to periodically make an API call on a regular interval.
+ * This is lifted from: https://overreacted.io/making-setinterval-declarative-with-react-hooks/.
+ */
+export default function useInterval(callback, delay) {
+  const savedCallback = useRef();
+
+  // Remember the latest callback
+  useEffect(() => {
+    savedCallback.current = callback;
+  }, [callback]);
+
+  // Set up the interval
+  useEffect(() => {
+    function tick() {
+      savedCallback.current();
+    }
+
+    if (delay !== null) {
+      const id = setInterval(tick, delay);
+      return () => clearInterval(id);
+    }
+
+    return null;
+  }, [delay]);
+}


### PR DESCRIPTION
[MICROBA-1621]
* Add a table to the BulkEmailTaskHistory component of the task manager.
* Add a table to the BulkEmailPendingTasks component of the task manager.
* Extract messages to messages.js.
* Add custom hook used to make REST API calls to edx-platform on a regular cadence (every 30 seconds).
* Use the new hook in BulkEmailPendingTasks to retrieve pending instructor tasks for display in a table.

Screenshots:
**Pending Tasks table**
![image](https://user-images.githubusercontent.com/3229735/150205673-edbd343f-bc45-48db-bc17-60eb401e47c2.png)

**Pending Tasks table (empty)**
![image](https://user-images.githubusercontent.com/3229735/150205941-1e787657-b3a2-4ecd-8325-9cf2ca6338e2.png)

**Email Task History**
![image](https://user-images.githubusercontent.com/3229735/150205766-8b879913-ec69-42a9-95fb-b0de32e3e60c.png)

**Email Task History (empty)**
![image](https://user-images.githubusercontent.com/3229735/150205861-050211d2-40fb-4b3c-8ae6-00e89bb68bca.png)
