### PR TITLE
fix: (MICROBA-1743) Minor UI updates after bug bash

### DIFF
--- a/src/components/bulk-email-tool/text-editor/TextEditor.jsx
+++ b/src/components/bulk-email-tool/text-editor/TextEditor.jsx
@@ -31,6 +31,7 @@ export default function TextEditor(props) {
         selector: 'textarea#editor',
         height: 600,
         branding: false,
+        menubar: 'edit view insert format table tools',
         plugins: 'advlist code emoticons link lists table image language',
         toolbar: 'formatselect fontselect bold italic underline forecolor | code bullist numlist alignlef aligncenter alignright alignjustify indent | blockquote link emoticons image | language',
         skin: false,

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -22,7 +22,7 @@ subscribe(APP_READY, () => {
       <Header />
       <div className="container">
         <Switch>
-          <AuthenticatedPageRoute path="/courses/:courseId/instructor/bulk_email" component={BulkEmailTool} />
+          <AuthenticatedPageRoute path="/courses/:courseId/bulk_email" component={BulkEmailTool} />
         </Switch>
       </div>
       <Footer />


### PR DESCRIPTION
[MICROBA-1743]

* Remove `instructor` from the path of the bulk course email tool in the Comms MFE.
* Remove `file` option from TinyMCE text editor.

Before removing `File` option:
<img width="830" alt="Screen Shot 2022-03-07 at 9 20 37 AM" src="https://user-images.githubusercontent.com/3229735/157065485-34998aae-353a-4ae3-9012-005ab785d611.png">

After removing the `File` option:
<img width="897" alt="Screen Shot 2022-03-07 at 9 21 58 AM" src="https://user-images.githubusercontent.com/3229735/157069096-b87a071f-199d-4e70-afad-b63e7fcadbc4.png">

Removing `instructor` from the URL path:
<img width="896" alt="Screen Shot 2022-03-07 at 9 22 11 AM" src="https://user-images.githubusercontent.com/3229735/157069172-f2a5fc33-c46b-4802-9d5d-3f4c28d68801.png">

