### PR TITLE
fix: Update webpack config to be less strict

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4257,9 +4257,9 @@
       "dev": true
     },
     "@edx/brand": {
-      "version": "npm:@edx/brand-edx.org@2.0.3",
-      "resolved": "https://registry.npmjs.org/@edx/brand-edx.org/-/brand-edx.org-2.0.3.tgz",
-      "integrity": "sha512-QRmq2su1Xy+9GhY3NRZ+WdjtYWHmgfuKbVCW2skxgfgW9Q6kea8L6LrgigfrZtW+kQq/KdX2tVJcYBkB9xALtQ=="
+      "version": "npm:@edx/brand-openedx@1.1.0",
+      "resolved": "https://registry.npmjs.org/@edx/brand-openedx/-/brand-openedx-1.1.0.tgz",
+      "integrity": "sha512-ne2ZKF1r0akkt0rEzCAQAk4cTDTI2GiWCpc+T7ldQpw9X57OnUB16dKsFNe40C9uEjL5h3Ps/ZsFM5dm4cIkEQ=="
     },
     "@edx/eslint-config": {
       "version": "1.2.0",
@@ -5861,26 +5861,18 @@
       }
     },
     "@edx/frontend-component-header": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-component-header/-/frontend-component-header-2.3.0.tgz",
-      "integrity": "sha512-X3udm6d/Y4fOZXvu+KNaMI3x4WUO7sXjXAKFXycz83H3AdO/Whw9qph6iMjF50oliKydSzS22KR0VKXxEEZIUw==",
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-component-header/-/frontend-component-header-2.4.5.tgz",
+      "integrity": "sha512-II0+1cKLKLT954uStqWNpFo+gVn3AyFSD+kIer7NOaH5PB/XpYdsxu4PUIftFeYbrFY3SHsBDALjOsRT+LFNsg==",
       "requires": {
+        "@fortawesome/fontawesome-svg-core": "1.2.36",
+        "@fortawesome/free-brands-svg-icons": "5.15.4",
+        "@fortawesome/free-regular-svg-icons": "5.15.4",
+        "@fortawesome/free-solid-svg-icons": "5.15.4",
+        "@fortawesome/react-fontawesome": "^0.1.14",
         "babel-polyfill": "6.26.0",
         "react-responsive": "8.2.0",
         "react-transition-group": "4.4.2"
-      },
-      "dependencies": {
-        "react-transition-group": {
-          "version": "4.4.2",
-          "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.2.tgz",
-          "integrity": "sha512-/RNYfRAMlZwDSr6z4zNKV6xu53/e2BuaBbGhbyYIXTrmgu/bGHzmqOs7mJSJBHy9Ud+ApHx3QjrkKSp1pxvlFg==",
-          "requires": {
-            "@babel/runtime": "^7.5.5",
-            "dom-helpers": "^5.0.1",
-            "loose-envify": "^1.4.0",
-            "prop-types": "^15.6.2"
-          }
-        }
       }
     },
     "@edx/frontend-platform": {

--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
     "url": "https://github.com/edx/frontend-app-communications/issues"
   },
   "dependencies": {
-    "@edx/brand": "npm:@edx/brand-edx.org@^2.0.3",
+    "@edx/brand": "npm:@edx/brand-openedx@1.1.0",
     "@edx/frontend-component-footer": "10.1.6",
-    "@edx/frontend-component-header": "2.3.0",
+    "@edx/frontend-component-header": "^2.4.2",
     "@edx/frontend-platform": "1.12.7",
     "@edx/paragon": "16.3.2",
     "@edx/tinymce-language-selector": "^1.1.0",

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -1,0 +1,29 @@
+const { createConfig } = require('@edx/frontend-build');
+
+const config = createConfig('webpack-dev');
+
+/**
+ * Webpack5 is now stricter when evaluating import statements. By default, Webpack5 expects import statements to include
+ * file extensions now.
+ *
+ * We want to be able to support overriding and injecting a branded header and footer in the MFE. However, the header
+ * and footer components have dependencies using older versions of Babel that are not Webpack5 compliant.
+ *
+ * This rule allows us to workaround the issue by telling Webpack to not be so strict.
+ *
+ * The solution is pulled from
+ * https://stackoverflow.com/questions/65922329/babel-cant-resolve-imports-in-it-its-own-source-code and more details
+ * can be found here: https://github.com/webpack/webpack/issues/11467#issuecomment-808618999/
+ */
+const webpack5esmInteropRule = {
+  test: /\.m?js/,
+  resolve: {
+    fullySpecified: false,
+  },
+};
+
+const otherRules = config.module.rules;
+
+config.module.rules = [webpack5esmInteropRule, ...otherRules];
+
+module.exports = config;

--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -4,4 +4,18 @@ const config = createConfig('webpack-prod');
 
 config.module.rules[0].exclude = /node_modules\/(?!(tinymce|@tinymce|@edx))/;
 
+/**
+ * See comment in webpack.dev.config.js for details on this rule and why it is needed.
+ */
+const webpack5esmInteropRule = {
+  test: /\.m?js/,
+  resolve: {
+    fullySpecified: false,
+  },
+};
+
+const otherRules = config.module.rules;
+
+config.module.rules = [webpack5esmInteropRule, ...otherRules];
+
 module.exports = config;


### PR DESCRIPTION
[MICROBA-1743]

Fixes an issue where we couldn't override the header and footer with the branded versiom within the Comms MFE because some of the dependencies of the branded components are not currently Webpack5 compliant. Adds a rule to make webpack5 less strict with imports that do not include a file extension.

This also includes a change so that the Comms MFE uses the Open edX branded colors/styles by default.