### PR TITLE
fix: [Microba-1741] Fix email image upload

### DIFF
--- a/src/components/bulk-email-tool/text-editor/TextEditor.jsx
+++ b/src/components/bulk-email-tool/text-editor/TextEditor.jsx
@@ -38,6 +38,7 @@ export default function TextEditor(props) {
         content_style: `${contentUiCss.toString()}\n${contentCss.toString()}`,
         extended_valid_elements: 'span[lang|id] -span',
         block_unsupported_drop: false,
+        paste_data_images: true,
       }}
       onChange={onChange}
       onKeyUp={onKeyUp}


### PR DESCRIPTION
Image uploads were broken for 2 reasons on stage:
  1. Our bleaching on the server was too strong. it was pulling out
     attributes inside of the image tags that allowed base64 encoding to
     work properly.
  2. The paste_data_images needs to be set to true to allow for dragging
     and dropping of images into the editor

Since bleach has been rolled back for now, adding this setting should
allow for images to be properly uploaded.