### PR TITLE
fix: fix oversized logo in header

### DIFF
--- a/src/components/page-container/PageContainer.jsx
+++ b/src/components/page-container/PageContainer.jsx
@@ -8,6 +8,8 @@ import { Spinner } from '@edx/paragon';
 
 import { getCohorts, getCourseHomeCourseMetadata } from './data/api';
 
+import './PageContainer.scss';
+
 export const CourseMetadataContext = React.createContext();
 
 export default function PageContainer(props) {
@@ -58,6 +60,7 @@ export default function PageContainer(props) {
       <CourseMetadataContext.Provider value={courseMetadata}>
         <>
           <Header
+            className="learning-header"
             courseOrg={courseMetadata.org}
             courseNumber={courseMetadata.number}
             courseTitle={courseMetadata.title}

--- a/src/components/page-container/PageContainer.scss
+++ b/src/components/page-container/PageContainer.scss
@@ -1,0 +1,9 @@
+.learning-header {
+  > div > a {
+    img {
+      top: 0.1em;
+      height: 2rem;
+      margin-right: 1rem;
+    }
+  }
+}


### PR DESCRIPTION
[MICROBA-1743]

* Add styling overrides for images and text in header to make logo sizes consistent in the PageContainer component.

Before:
![image](https://user-images.githubusercontent.com/3229735/158187628-7eda6802-714b-46ee-9306-f1e66c8d881f.png)

After: 
![image](https://user-images.githubusercontent.com/3229735/158187649-ae1059b2-4992-4724-9dc1-00bcb122cd6b.png)
