### PR TITLE
fix: Support feedback of tool

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en-us">
   <head>
-      <title>Application Template | <%= process.env.SITE_NAME %></title>
+      <title>Communications | <%= process.env.SITE_NAME %></title>
       <meta charset="utf-8">
       <meta name="viewport" content="width=device-width, initial-scale=1.0">
       <link rel="shortcut icon" href="<%=htmlWebpackPlugin.options.FAVICON_URL%>" type="image/x-icon" />

--- a/src/components/bulk-email-tool/text-editor/TextEditor.jsx
+++ b/src/components/bulk-email-tool/text-editor/TextEditor.jsx
@@ -35,12 +35,13 @@ export default function TextEditor(props) {
         menubar: 'edit view insert format table tools',
         plugins: 'advlist code emoticons link lists table image language codesample',
         toolbar:
-          'formatselect fontselect bold italic underline forecolor | codesample bullist numlist alignlef aligncenter alignright alignjustify indent | blockquote link emoticons image code| language',
+          'formatselect fontselect bold italic underline forecolor | codesample bullist numlist alignleft aligncenter alignright alignjustify indent | blockquote link emoticons image code| language',
         skin: false,
         content_css: false,
         content_style: `${contentUiCss.toString()}\n${contentCss.toString()}`,
         extended_valid_elements: 'span[lang|id] -span',
         block_unsupported_drop: false,
+        image_advtab: true,
       }}
       onChange={onChange}
       onKeyUp={onKeyUp}


### PR DESCRIPTION
- Missing left align tool (just a typo)
- Missing advanced image options (missing configuration)
- Page title was never set

Other issues such as email title, google+, and sender address are not
related to the MFE and are quirks to do with the staging environment.

left align
![image](https://user-images.githubusercontent.com/16495365/159981124-93a92bab-13b0-424d-b94b-e70d2fa209f7.png)

image advanced tab (ignore the modal styling I dont have the edX theme on)
![image](https://user-images.githubusercontent.com/16495365/159981202-e2567048-d2d6-43e4-ac62-daa7e387850d.png)

tab name
![image](https://user-images.githubusercontent.com/16495365/159981354-0f795eb1-f1fc-4a28-974b-9506275a0cb5.png)

