### PR TITLE
fix: disable emoticons to prevent messages from being cut off

### DIFF
--- a/src/components/bulk-email-tool/text-editor/TextEditor.jsx
+++ b/src/components/bulk-email-tool/text-editor/TextEditor.jsx
@@ -33,9 +33,9 @@ export default function TextEditor(props) {
         height: 600,
         branding: false,
         menubar: 'edit view insert format table tools',
-        plugins: 'advlist code emoticons link lists table image language codesample',
+        plugins: 'advlist code link lists table image language codesample',
         toolbar:
-          'formatselect fontselect bold italic underline forecolor | codesample bullist numlist alignleft aligncenter alignright alignjustify indent | blockquote link emoticons image code| language',
+          'formatselect fontselect bold italic underline forecolor | codesample bullist numlist alignleft aligncenter alignright alignjustify indent | blockquote link image code | language',
         skin: false,
         content_css: false,
         content_style: `${contentUiCss.toString()}\n${contentCss.toString()}`,


### PR DESCRIPTION
For some reason, the emoticons toolbar was causing errors and making messages cut off. For now, we're just going to disable the tool on the toolbar.