### PR TITLE
fix: [MICROBA-1799] fix bulk email tool on safari

### DIFF
--- a/src/components/bulk-email-tool/bulk-email-form/TaskAlertModal.jsx
+++ b/src/components/bulk-email-tool/bulk-email-form/TaskAlertModal.jsx
@@ -35,7 +35,14 @@ function TaskAlertModal(props) {
               id="bulk.email.form.recipients.Contine"
               defaultMessage="Continue"
               description="Continue button for the task alert"
-            />
+            >
+              { // FormattedMessage wraps the translated string in a <span/> by default. This was
+                // causing strange click event target issues in safari. To solve this, we want to
+                // wrap the string in a fragment instead of a span, so that the whole button considered
+                // a "button" target, and not a "span inside a button"
+                msg => <>{msg}</>
+              }
+            </FormattedMessage>
           </Button>
         </ActionRow>
       )}

--- a/src/components/bulk-email-tool/text-editor/TextEditor.jsx
+++ b/src/components/bulk-email-tool/text-editor/TextEditor.jsx
@@ -33,9 +33,9 @@ export default function TextEditor(props) {
         height: 600,
         branding: false,
         menubar: 'edit view insert format table tools',
-        plugins: 'advlist code link lists table image language codesample',
+        plugins: 'advlist code link lists table image codesample',
         toolbar:
-          'formatselect fontselect bold italic underline forecolor | codesample bullist numlist alignleft aligncenter alignright alignjustify indent | blockquote link image code | language',
+          'formatselect fontselect bold italic underline forecolor | codesample bullist numlist alignleft aligncenter alignright alignjustify indent | blockquote link image code ',
         skin: false,
         content_css: false,
         content_style: `${contentUiCss.toString()}\n${contentCss.toString()}`,


### PR DESCRIPTION
Course teams were having issues sending bulk emails to themselves and
students. This was caused by two problems.

1. The language selector tool was failing because of no default language
   settings in safari is possible
2. The translated string for the "continue" button on the submit modal
   was messing with the markup and causing the event to POST the email
to not properly fire.

To fix the language issue for now, we are disabling the language
selector plugin. To fix the markup issue, we are forcing the string to
render in a fragment to remove the additional span, allowing the event
to fire no matter where the user clicks the button.