### PR TITLE
fix: [MICROBA-1905] fix cancel button

### DIFF
--- a/src/components/bulk-email-tool/bulk-email-form/data/actions.js
+++ b/src/components/bulk-email-tool/bulk-email-form/data/actions.js
@@ -9,6 +9,10 @@ export const clearEditor = () => ({
   type: 'CLEAR_EDITOR',
 });
 
+export const clearErrorState = () => ({
+  type: 'CLEAR_ERROR',
+});
+
 export const copyToEditor = (payload) => ({
   type: 'COPY_TO_EDITOR',
   payload,

--- a/src/components/bulk-email-tool/bulk-email-form/data/reducer.js
+++ b/src/components/bulk-email-tool/bulk-email-form/data/reducer.js
@@ -50,6 +50,14 @@ export function editorReducer(state, action) {
         editMode: false,
         schedulingId: '',
         emailId: null,
+        errorRetrievingData: false,
+        formComplete: false,
+      };
+    case 'CLEAR_ERROR':
+      return {
+        ...state,
+        errorRetrievingData: false,
+        formComplete: false,
       };
     case 'SET_EDIT_MODE':
       return {
@@ -68,6 +76,7 @@ export function editorReducer(state, action) {
         ...state,
         isLoading: false,
         errorRetrievingData: false,
+        formComplete: true,
         ...action.payload,
       };
     case 'PATCH_FAILURE':
@@ -75,6 +84,7 @@ export function editorReducer(state, action) {
         ...state,
         isLoading: false,
         errorRetrievingData: true,
+        formComplete: false,
       };
     case 'POST_BULK_EMAIL':
       return state;
@@ -88,6 +98,7 @@ export function editorReducer(state, action) {
         ...state,
         isLoading: false,
         errorRetrievingData: false,
+        formComplete: true,
         ...action.payload,
       };
     case 'POST_FAILURE':
@@ -95,6 +106,7 @@ export function editorReducer(state, action) {
         ...state,
         isLoading: false,
         errorRetrievingData: true,
+        formComplete: false,
       };
     default:
       return state;
@@ -112,6 +124,7 @@ export const editorInitialState = {
   emailId: null,
   isLoading: false,
   errorRetrievingData: false,
+  formComplete: false,
 };
 
 export default editorReducer;


### PR DESCRIPTION
The various form states were getting mixed up during error handling,
which lead to some strange situations where the cancel button was
appearing when it shouldnt have been. This PR centralizes all of the
form state changes into a useEffect hook to handle any and all state
changes throughout the form. This approach not only centralizes the
fragmented code, but prevents the state mixups that were happening
previously.

It also has the added benefit if down the line more state changes need
to be added, the changes are all happening in one place.