### PR TITLE
fix: await post to properly update form

### DIFF
--- a/src/components/bulk-email-tool/bulk-email-form/BulkEmailForm.jsx
+++ b/src/components/bulk-email-tool/bulk-email-form/BulkEmailForm.jsx
@@ -152,10 +152,10 @@ function BulkEmailForm(props) {
     if (validateEmailForm()) {
       if (editor.editMode) {
         const editedEmail = formatDataForFormAction(FORM_ACTIONS.PATCH);
-        dispatch(editScheduledEmailThunk(editedEmail, courseId, editor.schedulingId));
+        await dispatch(editScheduledEmailThunk(editedEmail, courseId, editor.schedulingId));
       } else {
         const emailData = formatDataForFormAction(FORM_ACTIONS.POST);
-        dispatch(postBulkEmailThunk(emailData, courseId));
+        await dispatch(postBulkEmailThunk(emailData, courseId));
       }
       dispatch(getScheduledBulkEmailThunk(courseId, 1));
     }


### PR DESCRIPTION
The form wasn't awaiting the post/patch calls when creating new emails. Then when it went to update the scheduled emails table, it did not update properly. this fixes the issue, and the table will now update after the new email is posted.