### PR TITLE
fix: [MICROBA-1903] validate date time

### DIFF
--- a/src/components/bulk-email-tool/bulk-email-form/BulkEmailForm.jsx
+++ b/src/components/bulk-email-tool/bulk-email-form/BulkEmailForm.jsx
@@ -129,7 +129,9 @@ function BulkEmailForm(props) {
 
   const validateDateTime = (date, time) => {
     if (isScheduled) {
-      return !!date && !!time;
+      const now = new Date();
+      const newSchedule = new Date(`${editor.scheduleDate} ${editor.scheduleTime}`);
+      return !!date && !!time && newSchedule > now;
     }
     return true;
   };

--- a/src/components/bulk-email-tool/bulk-email-form/ScheduleEmailForm.jsx
+++ b/src/components/bulk-email-tool/bulk-email-form/ScheduleEmailForm.jsx
@@ -61,7 +61,7 @@ function ScheduleEmailForm(props) {
         <Form.Control.Feedback className="pb-2" hasIcon type="invalid">
           <FormattedMessage
             id="bulk.email.form.dateTime.error"
-            defaultMessage="Date and time cannot be blank"
+            defaultMessage="Date and time cannot be blank, and must be a date in the future"
             description="An error message located under the date-time selector. Visible only on failure."
           />
         </Form.Control.Feedback>

--- a/src/components/bulk-email-tool/bulk-email-form/test/BulkEmailForm.test.jsx
+++ b/src/components/bulk-email-tool/bulk-email-form/test/BulkEmailForm.test.jsx
@@ -10,11 +10,15 @@ import {
 import BulkEmailForm from '..';
 import * as bulkEmailFormApi from '../data/api';
 import { BulkEmailContext, BulkEmailProvider } from '../../bulk-email-context';
+import { formatDate } from '../../../../utils/formatDateAndTime';
 
 jest.mock('../../text-editor/TextEditor');
 
 const appendMock = jest.spyOn(FormData.prototype, 'append');
 const dispatchMock = jest.fn();
+
+const tomorrow = new Date();
+tomorrow.setDate(new Date().getDate() + 1);
 
 function renderBulkEmailForm() {
   return (
@@ -103,7 +107,7 @@ describe('bulk-email-form', () => {
     fireEvent.click(submitButton);
     const continueButton = await screen.findByRole('button', { name: /continue/i });
     fireEvent.click(continueButton);
-    expect(screen.getByText('Date and time cannot be blank'));
+    expect(screen.getByText('Date and time cannot be blank, and must be a date in the future'));
   });
   test('Adds scheduling data to POST requests when schedule is selected', async () => {
     const postBulkEmailInstructorTask = jest.spyOn(bulkEmailFormApi, 'postBulkEmailInstructorTask');
@@ -116,12 +120,12 @@ describe('bulk-email-form', () => {
     const submitButton = screen.getByText('Schedule Email');
     const scheduleDate = screen.getByTestId('scheduleDate');
     const scheduleTime = screen.getByTestId('scheduleTime');
-    fireEvent.change(scheduleDate, { target: { value: '2020-05-24' } });
+    fireEvent.change(scheduleDate, { target: { value: formatDate(tomorrow) } });
     fireEvent.change(scheduleTime, { target: { value: '10:00' } });
     fireEvent.click(submitButton);
     const continueButton = await screen.findByRole('button', { name: /continue/i });
     fireEvent.click(continueButton);
-    expect(appendMock).toHaveBeenCalledWith('schedule', expect.stringContaining('2020-05-24'));
+    expect(appendMock).toHaveBeenCalledWith('schedule', expect.stringContaining(formatDate(tomorrow)));
     expect(postBulkEmailInstructorTask).toHaveBeenCalledWith(expect.any(FormData), expect.stringContaining('test'));
   });
   test('will PATCH instead of POST when in edit mode', async () => {
@@ -134,7 +138,7 @@ describe('bulk-email-form', () => {
           emailBody: 'test',
           emailSubject: 'test',
           emailRecipients: ['test'],
-          scheduleDate: '2020-05-24',
+          scheduleDate: formatDate(tomorrow),
           scheduleTime: '10:00',
           schedulingId: 1,
           emailId: 1,

--- a/src/components/bulk-email-tool/bulk-email-task-manager/bulk-email-scheduled-emails-table/BulkEmailScheduledEmailsTable.jsx
+++ b/src/components/bulk-email-tool/bulk-email-task-manager/bulk-email-scheduled-emails-table/BulkEmailScheduledEmailsTable.jsx
@@ -16,6 +16,7 @@ import messages from './messages';
 import ViewEmailModal from '../ViewEmailModal';
 import { copyToEditor } from '../../bulk-email-form/data/actions';
 import TaskAlertModal from '../../task-alert-modal';
+import { formatDate, formatTime } from '../../../../utils/formatDateAndTime';
 
 function flattenScheduledEmailsArray(emails) {
   return emails.map((email) => ({
@@ -82,21 +83,6 @@ function BulkEmailScheduledEmailsTable({ intl }) {
     } else {
       dispatch(getScheduledBulkEmailThunk(courseId, pageIndex + 1));
     }
-  };
-
-  const normalizeDigits = (value) => (value < 10 ? `0${value}` : value);
-  const formatDate = (date) => {
-    const day = normalizeDigits(date.getDate());
-    const month = normalizeDigits(date.getMonth() + 1);
-    const year = date.getFullYear();
-
-    return `${year}-${month}-${day}`;
-  };
-  const formatTime = (date) => {
-    const hours = normalizeDigits(date.getHours());
-    const mins = normalizeDigits(date.getMinutes());
-
-    return `${hours}:${mins}`;
   };
 
   const handleEditEmail = (row) => {

--- a/src/utils/formatDateAndTime.js
+++ b/src/utils/formatDateAndTime.js
@@ -1,0 +1,14 @@
+const normalizeDigits = (value) => (value < 10 ? `0${value}` : value);
+export const formatDate = (date) => {
+  const day = normalizeDigits(date.getDate());
+  const month = normalizeDigits(date.getMonth() + 1);
+  const year = date.getFullYear();
+
+  return `${year}-${month}-${day}`;
+};
+export const formatTime = (date) => {
+  const hours = normalizeDigits(date.getHours());
+  const mins = normalizeDigits(date.getMinutes());
+
+  return `${hours}:${mins}`;
+};


### PR DESCRIPTION
Currently, we do not validate date and time to be a date on the future on the front end. We do handle this on the backend. This updates form validation to force the user to enter a data in the future.