### PR TITLE
Unchecking and disabling boxes when "All Learners" is selected

### DIFF
--- a/src/components/bulk-email-tool/bulk-email-form/BulkEmailForm.jsx
+++ b/src/components/bulk-email-tool/bulk-email-form/BulkEmailForm.jsx
@@ -122,6 +122,14 @@ function BulkEmailForm(props) {
   const onRecipientChange = (event) => {
     if (event.target.checked) {
       dispatch(addRecipient(event.target.value));
+      // if "All Learners" is checked then we want to remove any cohorts, verified learners, and audit learners
+      if (event.target.value === 'learners') {
+        editor.emailRecipients.forEach(recipient => {
+          if (/^cohort/.test(recipient) || /^track/.test(recipient)) {
+            dispatch(removeRecipient(recipient));
+          }
+        });
+      }
     } else {
       dispatch(removeRecipient(event.target.value));
     }

--- a/src/components/bulk-email-tool/bulk-email-form/bulk-email-recipient/BulkEmailRecipient.jsx
+++ b/src/components/bulk-email-tool/bulk-email-form/bulk-email-recipient/BulkEmailRecipient.jsx
@@ -69,6 +69,7 @@ export default function BulkEmailRecipient(props) {
             <Form.Checkbox
               key={cohort}
               value={`cohort:${cohort}`}
+              disabled={selectedGroups.find((group) => group === DEFAULT_GROUPS.ALL_LEARNERS)}
               className="col col-lg-4 col-sm-6 col-12"
             >
               <FormattedMessage
@@ -94,7 +95,6 @@ export default function BulkEmailRecipient(props) {
         <Form.Checkbox
           key="learners"
           value="learners"
-          disabled={selectedGroups.find((group) => group === (DEFAULT_GROUPS.AUDIT || DEFAULT_GROUPS.VERIFIED))}
           className="col col-lg-4 col-sm-6 col-12"
         >
           <FormattedMessage

--- a/src/components/bulk-email-tool/bulk-email-form/data/__factories__/bulkEmailFormCohort.factory.js
+++ b/src/components/bulk-email-tool/bulk-email-form/data/__factories__/bulkEmailFormCohort.factory.js
@@ -1,0 +1,7 @@
+import { Factory } from 'rosie'; // eslint-disable-line import/no-extraneous-dependencies
+
+export default Factory.define('')
+  .attr('cohorts', [
+    'Gnarly',
+    'Righteous',
+  ]);


### PR DESCRIPTION
[Update] The original PR misunderstood what the ticket was asking for. We actually DO NOT want to check any learner boxes, but instead simply disable them when "All Learners" is checked. This still gets the point across that all learners will be sent an email while not bogging down the backend with duplicated requests. The latest push to this PR addresses this and ensures that it works for any added cohorts as well. There is also a test for this new functionality.

[Updated video]


https://user-images.githubusercontent.com/92897870/182911869-5dbb8eef-9fb8-4884-b3a2-ab913015fd28.mov


[Original comment, can be ignored]
This PR addresses one of the issues brought up during the bug bash. Cohorts were not getting checked when "All learners" was selected, however, emails were still being sent. We found that this functionality provides a better user experience. We don't want users to get confused and think an email didn't send because the checkbox was empty.


