### PR TITLE
fix: [APER-1936] Changes for a11y review

### DIFF
--- a/src/components/bulk-email-tool/BulkEmailTool.jsx
+++ b/src/components/bulk-email-tool/BulkEmailTool.jsx
@@ -18,13 +18,13 @@ export default function BulkEmailTool() {
   return (
     <CourseMetadataContext.Consumer>
       {(courseMetadata) => (courseMetadata.originalUserIsStaff ? (
-        <div>
+        <>
           <NavigationTabs courseId={courseId} tabData={courseMetadata.tabs} />
           <BulkEmailProvider>
             <Container size="md">
               <BackToInstructor />
               <div className="row pb-4.5">
-                <h1 className="text-primary-500">
+                <h1 className="text-primary-500" id="main-content">
                   <FormattedMessage
                     id="bulk.email.send.email.header"
                     defaultMessage="Send an email"
@@ -40,7 +40,7 @@ export default function BulkEmailTool() {
               </div>
             </Container>
           </BulkEmailProvider>
-        </div>
+        </>
       ) : (
         <ErrorPage />
       ))}

--- a/src/components/bulk-email-tool/bulk-email-task-manager/BulkEmailContentHistory.jsx
+++ b/src/components/bulk-email-tool/bulk-email-task-manager/BulkEmailContentHistory.jsx
@@ -108,8 +108,8 @@ function BulkEmailContentHistory({ intl }) {
         Header: '',
         Cell: ({ row }) => (
           <Button variant="link" className="px-1" onClick={() => onViewMessageClick(tableData[row.index])}>
-            <span className="sr-only"> {row.index}</span>
             {intl.formatMessage(messages.buttonViewMessage)}
+            <span className="sr-only">&nbsp;{row.index}</span>
           </Button>
         ),
       },

--- a/src/components/bulk-email-tool/bulk-email-task-manager/BulkEmailContentHistory.jsx
+++ b/src/components/bulk-email-tool/bulk-email-task-manager/BulkEmailContentHistory.jsx
@@ -108,6 +108,7 @@ function BulkEmailContentHistory({ intl }) {
         Header: '',
         Cell: ({ row }) => (
           <Button variant="link" className="px-1" onClick={() => onViewMessageClick(tableData[row.index])}>
+            <span className="sr-only"> {row.index}</span>
             {intl.formatMessage(messages.buttonViewMessage)}
           </Button>
         ),

--- a/src/components/bulk-email-tool/bulk-email-task-manager/BulkEmailPendingTasksAlert.jsx
+++ b/src/components/bulk-email-tool/bulk-email-task-manager/BulkEmailPendingTasksAlert.jsx
@@ -16,6 +16,7 @@ export default function BulkEmailPendingTasksAlert() {
         <Hyperlink
           destination={`${getConfig().LMS_BASE_URL}/courses/${window.location.pathname.split('/')[2]}/instructor#view-course-info`}
           target="_blank"
+          isInline
           showLaunchIcon={false}
         >
           <FormattedMessage

--- a/src/components/bulk-email-tool/bulk-email-task-manager/test/BulkEmailContentHistory.test.jsx
+++ b/src/components/bulk-email-tool/bulk-email-task-manager/test/BulkEmailContentHistory.test.jsx
@@ -71,6 +71,8 @@ describe('BulkEmailContentHistory component', () => {
       expect(await screen.findByText(email.requester)).toBeTruthy();
       expect(await screen.findByText(email.sent_to.join(', '))).toBeTruthy();
       expect(await screen.findByText(email.email.subject)).toBeTruthy();
+      // verify screen reader only <span />
+      expect(await screen.findByText('0')).toHaveClass('sr-only');
       expect(await screen.findAllByText('View Message')).toBeTruthy();
     });
   });

--- a/src/components/page-container/PageContainer.jsx
+++ b/src/components/page-container/PageContainer.jsx
@@ -65,7 +65,9 @@ export default function PageContainer(props) {
             courseNumber={courseMetadata.number}
             courseTitle={courseMetadata.title}
           />
-          {children}
+          <main>
+            {children}
+          </main>
           <Footer />
         </>
       </CourseMetadataContext.Provider>


### PR DESCRIPTION
changes as per the a11y review shake out as follows:

> The SkipNav link (Skip to main content) should jump to the H1 or to a link just above the H1, which would show on focus (you could use the same style as the SkipNav link to do this).

The skipNav link now properly anchors to the `H1`:

![image](https://user-images.githubusercontent.com/16495365/185453247-34ba1240-24b2-4409-bf54-52d2bc630496.png)

---
> The <html> element needs a lang attribute

![image](https://user-images.githubusercontent.com/16495365/185453319-4944ffa1-c4d7-4299-ba2d-70199b506bea.png)

---
> The page needs a unique <title> (text used for the browser tab) in the <head>.

![image](https://user-images.githubusercontent.com/16495365/185453369-1c74f2b5-c815-4a64-b8b6-e6a07b390e7f.png)
![image](https://user-images.githubusercontent.com/16495365/185453442-79028b14-27ef-4f58-b6b4-236bc99b785e.png)

---
> The label Body above the TinyMCE editor has a for= attribute that points to a missing ID. I think that ID should be on the `<textarea>` just below it (not the `<div role="application">`). I'm not 100% sure on that but please add it to confirm.

As far as I can tell, this is done correctly, as the role is where the `TinyMCE` editor starts:
`The application role indicates to assistive technologies that an element and all of its children should be treated similar to a desktop application, and no traditional HTML interpretation techniques should be used. `

this was done my TinyMCE itself, and not by us, so I caution messing with it.

---
> In the alert where it says "To view all pending tasks, including email, visit Course Info..." that inline link should have the inline link styling, which includes an underline in all states.

![image](https://user-images.githubusercontent.com/16495365/185453813-b9a28043-a063-447f-bc9a-7aaa890c5d98.png)
![image](https://user-images.githubusercontent.com/16495365/185453849-7d49bfc5-db22-498d-ac2c-64a0710149f4.png)

---
> The page doesn't seem to have a `<main>` (though there is a `<header>` and `<footer>`. Could you add one where the blank div is now (first sibling after `<header>`)?

![image](https://user-images.githubusercontent.com/16495365/185454000-33039472-0a6a-49c4-b853-eb35defa97d7.png)

---
> In the email Task History table, there are a bunch of links with text of View Message. Links are supposed to be unique on the page. Could you append `<span class="sr-only"> X</span>` (where X is the message number) at the end of the links?  Note the leading space before X, so it reads correctly with TTS.

![image](https://user-images.githubusercontent.com/16495365/185454111-16c254f4-4f62-44ff-9ee9-d451777285aa.png)

---
> Are you sure that's the latest standard footer ?  The social media icons' color looks old for some reason. Not sure though. But on that note, the `<footer>` has aria-label="edX Home" which is totally random (so please just remove that), but I have seen that particular bug in older instances of the `<footer>`.

These were changed in an `edx-internal` PR: https://github.com/edx/edx-internal/pull/7003